### PR TITLE
Add Astro config example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ export default defineConfig({
 })
 ```
 
+### Astro config
+
+```js
+import {defineConfig} from 'astro/config'
+import unocss from 'unocss/vite'
+import {presetUno, transformerDirectives} from 'unocss'
+import presetDaisy from 'unocss-preset-daisy'
+
+export default defineConfig({
+	vite: {
+		plugins: [
+			unocss({
+				transformers: [transformerDirectives()],
+				presets: [presetUno(), presetDaisy()],
+			}),
+		],
+	}
+})
+```
+
 ### Nuxt config
 
 To use UnoCSS with Nuxt, `@unocss/nuxt` must be installed.


### PR DESCRIPTION
While not totally rocket science after knowing (Astro lets you pass configuration directly to Vite)[https://docs.astro.build/en/reference/configuration-reference/#vite], I thought this configuration could still be useful for those trying to make everything work just right!

I've tested locally, and while the hotreload update time is significant (5+ seconds), it works as expected. I'm guessing this is due to the large size of daisyUI as mentioned in the README. Let me know if this is abnormal though and indicative of incompatibility with Astro.